### PR TITLE
Optimized work with wallets and fixed a memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nftworlds</groupId>
     <artifactId>wrld-payments-api</artifactId>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
     <packaging>jar</packaging>
 
     <name>wrld-payments-api</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nftworlds</groupId>
     <artifactId>wrld-payments-api</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.6</version>
     <packaging>jar</packaging>
 
     <name>wrld-payments-api</name>

--- a/src/main/java/com/nftworlds/wallet/NFTWorlds.java
+++ b/src/main/java/com/nftworlds/wallet/NFTWorlds.java
@@ -1,6 +1,5 @@
 package com.nftworlds.wallet;
 
-import com.nftworlds.wallet.api.WalletAPI;
 import com.nftworlds.wallet.commands.WalletGUICommand;
 import com.nftworlds.wallet.config.Config;
 import com.nftworlds.wallet.contracts.nftworlds.Players;
@@ -9,6 +8,7 @@ import com.nftworlds.wallet.handlers.TimeoutHandler;
 import com.nftworlds.wallet.listeners.PlayerListener;
 import com.nftworlds.wallet.menus.WalletGUI;
 import com.nftworlds.wallet.objects.NFTPlayer;
+import com.nftworlds.wallet.objects.Wallet;
 import com.nftworlds.wallet.rpcs.Ethereum;
 import com.nftworlds.wallet.rpcs.Polygon;
 import lombok.Getter;
@@ -16,6 +16,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.h2.value.CaseInsensitiveConcurrentMap;
+
+import java.util.Map;
 
 public class NFTWorlds extends JavaPlugin {
     private static NFTWorlds plugin;
@@ -29,6 +32,8 @@ public class NFTWorlds extends JavaPlugin {
     //RPCs
     @Getter private Polygon polygonRPC;
     @Getter private Ethereum ethereumRPC;
+
+    private final Map<String, Wallet> wallets = new CaseInsensitiveConcurrentMap<>();
 
     public void onEnable() {
         plugin = this;
@@ -67,6 +72,18 @@ public class NFTWorlds extends JavaPlugin {
 
     public void registerCommands() {
         getCommand("wallet").setExecutor(new WalletGUICommand());
+    }
+
+    public void addWallet(Wallet wallet) {
+        wallets.put(wallet.getAddress(), wallet);
+    }
+
+    public Wallet getWallet(String address) {
+        return wallets.get(address);
+    }
+
+    public void removeWallet(Wallet wallet) {
+        wallets.remove(wallet.getAddress(), wallet);
     }
 
     public static NFTWorlds getInstance() {

--- a/src/main/java/com/nftworlds/wallet/contracts/nftworlds/Players.java
+++ b/src/main/java/com/nftworlds/wallet/contracts/nftworlds/Players.java
@@ -135,10 +135,7 @@ public class Players {
         UUID uuid = java.util.UUID.fromString (playerUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)","$1-$2-$3-$4-$5"));
         NFTPlayer nftPlayer = NFTPlayer.getByUUID(uuid);
         if (nftPlayer != null) {
-            Wallet previousWallet = nftPlayer.getWallets().set(0, new Wallet(nftPlayer, walletAddress.getValue()));
-            if (previousWallet != null) {
-                plugin.removeWallet(previousWallet);
-            }
+            nftPlayer.setPrimaryWallet(new Wallet(nftPlayer, walletAddress.getValue()));
 
             Player p = Bukkit.getPlayer(uuid);
             if (p.isOnline()) {

--- a/src/main/java/com/nftworlds/wallet/contracts/nftworlds/Players.java
+++ b/src/main/java/com/nftworlds/wallet/contracts/nftworlds/Players.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -119,7 +120,9 @@ public class Players {
     }
 
     public void paymentListener_handlePrimaryWalletSetEvent(Log log) {
-        if (debug) NFTWorlds.getInstance().getLogger().log(Level.INFO, "Primary wallet updated");
+        NFTWorlds plugin = NFTWorlds.getInstance();
+
+        if (debug) plugin.getLogger().log(Level.INFO, "Primary wallet updated");
 
         List<String> topics = log.getTopics();
         List<Type> data = FunctionReturnDecoder.decode(log.getData(), PolygonPlayers.PLAYERPRIMARYWALLETSET_EVENT.getNonIndexedParameters());
@@ -127,12 +130,16 @@ public class Players {
         String playerUUID = (String) data.get(0).getValue();
         Address walletAddress = (Address) FunctionReturnDecoder.decodeIndexedValue(topics.get(2), new TypeReference<Address>(false) {});
 
-        if (debug) NFTWorlds.getInstance().getLogger().log(Level.INFO, "Primary wallet of uuid " + playerUUID + " set to " + walletAddress);
+        if (debug) plugin.getLogger().log(Level.INFO, "Primary wallet of uuid " + playerUUID + " set to " + walletAddress);
 
         UUID uuid = java.util.UUID.fromString (playerUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)","$1-$2-$3-$4-$5"));
         NFTPlayer nftPlayer = NFTPlayer.getByUUID(uuid);
         if (nftPlayer != null) {
-            nftPlayer.getWallets().set(0, new Wallet(uuid, walletAddress.getValue()));
+            Wallet previousWallet = nftPlayer.getWallets().set(0, new Wallet(nftPlayer, walletAddress.getValue()));
+            if (previousWallet != null) {
+                plugin.removeWallet(previousWallet);
+            }
+
             Player p = Bukkit.getPlayer(uuid);
             if (p.isOnline()) {
                 p.sendMessage(ChatColor.translateAlternateColorCodes('&', " \n&7Your primary wallet has been set to &a" + walletAddress.getValue() + "&r\n "));
@@ -155,7 +162,7 @@ public class Players {
         UUID uuid = java.util.UUID.fromString (playerUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)","$1-$2-$3-$4-$5"));
         NFTPlayer nftPlayer = NFTPlayer.getByUUID(uuid);
         if (nftPlayer != null) {
-            nftPlayer.getWallets().add(new Wallet(uuid, walletAddress.getValue()));
+            nftPlayer.getWallets().add(new Wallet(nftPlayer, walletAddress.getValue()));
             Player p = Bukkit.getPlayer(uuid);
             if (p.isOnline()) {
                 p.sendMessage(ChatColor.translateAlternateColorCodes('&', " \n&7Your secondary wallets have been updated by adding &a" + walletAddress.getValue() + "&r\n "));
@@ -165,7 +172,9 @@ public class Players {
     }
 
     public void paymentListener_handleSecondaryWalletRemovedEvent(Log log) {
-        if (debug) NFTWorlds.getInstance().getLogger().log(Level.INFO, "Secondary wallet updated (removal)");
+        NFTWorlds plugin = NFTWorlds.getInstance();
+
+        if (debug) plugin.getLogger().log(Level.INFO, "Secondary wallet updated (removal)");
 
         List<String> topics = log.getTopics();
         List<Type> data = FunctionReturnDecoder.decode(log.getData(), PolygonPlayers.PLAYERSECONDARYWALLETREMOVED_EVENT.getNonIndexedParameters());
@@ -173,14 +182,24 @@ public class Players {
         String playerUUID = (String) data.get(0).getValue();
         Address walletAddress = (Address) FunctionReturnDecoder.decodeIndexedValue(topics.get(2), new TypeReference<Address>(false) {});
 
-        if (debug) NFTWorlds.getInstance().getLogger().log(Level.INFO, "Removed secondary wallet of " +  walletAddress.toString() + " from uuid " + playerUUID);
+        if (debug) plugin.getLogger().log(Level.INFO, "Removed secondary wallet of " +  walletAddress.toString() + " from uuid " + playerUUID);
 
         UUID uuid = java.util.UUID.fromString (playerUUID.replaceFirst("(\\p{XDigit}{8})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}{4})(\\p{XDigit}+)","$1-$2-$3-$4-$5"));
         NFTPlayer nftPlayer = NFTPlayer.getByUUID(uuid);
         if (nftPlayer != null) {
-            nftPlayer.getWallets().removeIf(wallet -> wallet.equals(new Wallet(uuid, walletAddress.getValue())));
+            String address = walletAddress.getValue();
+
+            Iterator<Wallet> iterator = nftPlayer.getWallets().iterator();
+            while (iterator.hasNext()) {
+                Wallet wallet = iterator.next();
+                if (address.equalsIgnoreCase(wallet.getAddress())) {
+                    plugin.removeWallet(wallet);
+                    iterator.remove();
+                }
+            }
+
             Player p = Bukkit.getPlayer(uuid);
-            if (p.isOnline()) {
+            if (p != null && p.isOnline()) {
                 p.sendMessage(ChatColor.translateAlternateColorCodes('&', " \n&7Your secondary wallets have been updated by removing &c" + walletAddress.getValue() + "&r\n "));
                 p.playSound(p.getLocation(), Sound.BLOCK_NOTE_BLOCK_BASS, 1, 1);
             }

--- a/src/main/java/com/nftworlds/wallet/objects/NFTPlayer.java
+++ b/src/main/java/com/nftworlds/wallet/objects/NFTPlayer.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class NFTPlayer {
 
+    private static final String EMPTY_ADDRESS = "0x0000000000000000000000000000000000000000";
+
     @Getter
     private static final ConcurrentHashMap<UUID, NFTPlayer> players = new ConcurrentHashMap<>();
 
@@ -31,9 +33,7 @@ public class NFTPlayer {
         String primary = playerContract.getPlayerPrimaryWallet(uuid.toString().replace("-", ""));
         List<String> secondary = playerContract.getPlayerSecondaryWallets(uuid.toString().replace("-", ""));
 
-        if (!primary.equalsIgnoreCase("0x0000000000000000000000000000000000000000")) {
-            linked = true;
-        }
+        linked = !primary.equalsIgnoreCase(EMPTY_ADDRESS);
 
         wallets = new ArrayList<>();
         wallets.add(new Wallet(this, primary));
@@ -60,6 +60,14 @@ public class NFTPlayer {
      */
     public Wallet getPrimaryWallet() {
         return wallets.get(0);
+    }
+
+    public void setPrimaryWallet(Wallet wallet) {
+        Wallet previousWallet = wallets.set(0, wallet);
+        if (previousWallet != null) {
+            NFTWorlds.getInstance().removeWallet(previousWallet);
+        }
+        linked = !wallet.getAddress().equalsIgnoreCase(EMPTY_ADDRESS);
     }
 
     /**

--- a/src/main/java/com/nftworlds/wallet/objects/Wallet.java
+++ b/src/main/java/com/nftworlds/wallet/objects/Wallet.java
@@ -1,12 +1,12 @@
 package com.nftworlds.wallet.objects;
 
-import com.nftworlds.wallet.qrmaps.LinkUtils;
 import com.nftworlds.wallet.NFTWorlds;
-import com.nftworlds.wallet.qrmaps.QRMapManager;
 import com.nftworlds.wallet.contracts.wrappers.common.ERC20;
 import com.nftworlds.wallet.contracts.wrappers.polygon.PolygonWRLDToken;
 import com.nftworlds.wallet.objects.payments.PaymentRequest;
 import com.nftworlds.wallet.objects.payments.PeerToPeerPayment;
+import com.nftworlds.wallet.qrmaps.LinkUtils;
+import com.nftworlds.wallet.qrmaps.QRMapManager;
 import lombok.Getter;
 import lombok.Setter;
 import net.md_5.bungee.api.ChatMessageType;
@@ -42,9 +42,9 @@ import java.util.UUID;
 public class Wallet {
 
     @Getter
-    private UUID associatedPlayer;
+    private final NFTPlayer owner;
     @Getter
-    private String address;
+    private final String address;
     @Getter
     @Setter
     private double polygonWRLDBalance;
@@ -60,8 +60,8 @@ public class Wallet {
     @Getter
     private static HashMap<String, Double> customEthereumBalances = new HashMap<>();
 
-    public Wallet(UUID associatedPlayer, String address) {
-        this.associatedPlayer = associatedPlayer;
+    public Wallet(NFTPlayer owner, String address) {
+        this.owner = owner;
         this.address = address;
 
         //Get balance initially
@@ -78,6 +78,12 @@ public class Wallet {
         this.polygonWRLDBalance = polygonBalance;
         this.ethereumWRLDBalance = ethereumBalance;
 
+        NFTWorlds.getInstance().addWallet(this);
+    }
+
+    @Deprecated
+    public UUID getAssociatedPlayer() {
+        return owner.getUuid();
     }
 
     /**
@@ -186,41 +192,40 @@ public class Wallet {
      */
     public <T> void requestWRLD(double amount, Network network, String reason, boolean canDuplicate, T payload) throws IOException, InterruptedException {
         NFTWorlds nftWorlds = NFTWorlds.getInstance();
-        NFTPlayer nftPlayer = NFTPlayer.getByUUID(associatedPlayer);
-        if (nftPlayer != null) {
-            Player player = Bukkit.getPlayer(nftPlayer.getUuid());
-            if (player != null) {
-                Uint256 refID = new Uint256(new BigInteger(256, new Random())); //NOTE: This generates a random Uint256 to use as a reference. Don't know if we want to change this or not.
-                long timeout = Instant.now().plus(nftWorlds.getNftConfig().getLinkTimeout(), ChronoUnit.SECONDS).toEpochMilli();
-                new PaymentRequest(associatedPlayer, amount, refID, network, reason, timeout, canDuplicate, payload);
-                String paymentLink = "https://nftworlds.com/pay/?to=" + nftWorlds.getNftConfig().getServerWalletAddress() + "&amount=" + amount + "&ref=" + refID.getValue().toString() + "&expires=" + (int) (timeout / 1000) + "&duplicate=" + canDuplicate;
+
+        UUID uuid = owner.getUuid();
+        Player player = Bukkit.getPlayer(uuid);
+        if (player != null) {
+            Uint256 refID = new Uint256(new BigInteger(256, new Random())); //NOTE: This generates a random Uint256 to use as a reference. Don't know if we want to change this or not.
+            long timeout = Instant.now().plus(nftWorlds.getNftConfig().getLinkTimeout(), ChronoUnit.SECONDS).toEpochMilli();
+            new PaymentRequest(uuid, amount, refID, network, reason, timeout, canDuplicate, payload);
+            String paymentLink = "https://nftworlds.com/pay/?to=" + nftWorlds.getNftConfig().getServerWalletAddress() + "&amount=" + amount + "&ref=" + refID.getValue().toString() + "&expires=" + (int) (timeout / 1000) + "&duplicate=" + canDuplicate;
 
 
-                MapView view = Bukkit.createMap(player.getWorld());
-                view.getRenderers().clear();
+            MapView view = Bukkit.createMap(player.getWorld());
+            view.getRenderers().clear();
 
-                QRMapManager renderer = new QRMapManager();
-                player.sendMessage(ChatColor.GOLD + "Incoming payment request for: " + ChatColor.WHITE + reason);
-                if (Bukkit.getServer().getPluginManager().getPlugin("Geyser-Spigot") != null && org.geysermc.connector.GeyserConnector.getInstance().getPlayerByUuid(player.getUniqueId()) != null) {
-                    String shortLink = LinkUtils.shortenURL(paymentLink);
-                    renderer.load(shortLink);
-                    // TODO: Better error handling
-                    view.addRenderer(renderer);
-                    ItemStack map = new ItemStack(Material.FILLED_MAP);
-                    MapMeta meta = (MapMeta) map.getItemMeta();
+            QRMapManager renderer = new QRMapManager();
+            player.sendMessage(ChatColor.GOLD + "Incoming payment request for: " + ChatColor.WHITE + reason);
+            if (Bukkit.getServer().getPluginManager().getPlugin("Geyser-Spigot") != null && org.geysermc.connector.GeyserConnector.getInstance().getPlayerByUuid(player.getUniqueId()) != null) {
+                String shortLink = LinkUtils.shortenURL(paymentLink);
+                renderer.load(shortLink);
+                // TODO: Better error handling
+                view.addRenderer(renderer);
+                ItemStack map = new ItemStack(Material.FILLED_MAP);
+                MapMeta meta = (MapMeta) map.getItemMeta();
 
-                    meta.setMapView(view);
-                    map.setItemMeta(meta);
+                meta.setMapView(view);
+                map.setItemMeta(meta);
 
-                    QRMapManager.playerPreviousItem.put(player.getUniqueId(), player.getInventory().getItem(0));
-                    player.getInventory().setItem(0, map);
-                    player.getInventory().setHeldItemSlot(0);
+                QRMapManager.playerPreviousItem.put(player.getUniqueId(), player.getInventory().getItem(0));
+                player.getInventory().setItem(0, map);
+                player.getInventory().setHeldItemSlot(0);
 
-                    player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&f&lScan the QR code on your map! Right click to exit."));
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&f&lScan the QR code on your map! Right click to exit."));
 
-                } else {
-                    player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&f&lPAY HERE: ") + ChatColor.GREEN + paymentLink);
-                }
+            } else {
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&f&lPAY HERE: ") + ChatColor.GREEN + paymentLink);
             }
         }
     }
@@ -296,9 +301,8 @@ public class Wallet {
      */
     public void createPlayerPayment(NFTPlayer to, double amount, Network network, String reason) {
         NFTWorlds nftWorlds = NFTWorlds.getInstance();
-        NFTPlayer nftPlayer = NFTPlayer.getByUUID(associatedPlayer);
-        if (nftPlayer != null && to != null) {
-            Player player = Bukkit.getPlayer(nftPlayer.getUuid());
+        if (to != null) {
+            Player player = Bukkit.getPlayer(owner.getUuid());
             if (player != null) {
                 if (!to.isLinked()) {
                     player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&cThis player does not have a wallet linked."));
@@ -306,11 +310,28 @@ public class Wallet {
                 }
                 Uint256 refID = new Uint256(new BigInteger(256, new Random()));
                 long timeout = Instant.now().plus(nftWorlds.getNftConfig().getLinkTimeout(), ChronoUnit.SECONDS).toEpochMilli();
-                new PeerToPeerPayment(to, nftPlayer, amount, refID, network, reason, timeout);
+                new PeerToPeerPayment(to, owner, amount, refID, network, reason, timeout);
                 String paymentLink = "https://nftworlds.com/pay/?to=" + to.getPrimaryWallet().getAddress() + "&amount=" + amount + "&ref=" + refID.getValue().toString() + "&expires=" + (int) (timeout / 1000);
                 player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&f&lPAY HERE: ") + ChatColor.GREEN + paymentLink);
             }
         }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+
+        Wallet wallet = (Wallet) object;
+        if (!Objects.equals(owner, wallet.owner)) return false;
+        return Objects.equals(address, wallet.address);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = owner != null ? owner.hashCode() : 0;
+        result = 31 * result + (address != null ? address.hashCode() : 0);
+        return result;
     }
 
 }

--- a/src/main/java/com/nftworlds/wallet/objects/Wallet.java
+++ b/src/main/java/com/nftworlds/wallet/objects/Wallet.java
@@ -81,11 +81,6 @@ public class Wallet {
         NFTWorlds.getInstance().addWallet(this);
     }
 
-    @Deprecated
-    public UUID getAssociatedPlayer() {
-        return owner.getUuid();
-    }
-
     /**
      * Get the wallet's WRLD balance
      */
@@ -238,7 +233,7 @@ public class Wallet {
      * @param reason
      */
     public void payWRLD(double amount, Network network, String reason) {
-        if (!NFTPlayer.getByUUID(getAssociatedPlayer()).isLinked()) {
+        if (!owner.isLinked()) {
             NFTWorlds.getInstance().getLogger().warning("Skipped outgoing transaction because wallet was not linked!");
             return;
         }
@@ -249,7 +244,7 @@ public class Wallet {
         }
 
         BigDecimal sending = Convert.toWei(BigDecimal.valueOf(amount), Convert.Unit.ETHER);
-        Player paidPlayer = Objects.requireNonNull(Bukkit.getPlayer(this.getAssociatedPlayer()));
+        Player paidPlayer = Objects.requireNonNull(Bukkit.getPlayer(owner.getUuid()));
         paidPlayer.spigot().sendMessage(ChatMessageType.ACTION_BAR,
                 new TextComponent(ChatColor.DARK_GREEN + "Incoming " + amount + " WRLD payment pending"));
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: WRLDPaymentsAPI
-version: 0.2.5
+version: 0.2.6
 authors: [Jacob, ArkDev]
 main: com.nftworlds.wallet.NFTWorlds
 api-version: 1.17

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: WRLDPaymentsAPI
-version: 0.2.4
+version: 0.2.5
 authors: [Jacob, ArkDev]
 main: com.nftworlds.wallet.NFTWorlds
 api-version: 1.17


### PR DESCRIPTION
Found and fixed 3 issues.

### 1. WRLD.paymentListener_handleTransferEvent()
This method can be called for transactions with wallets whose owners have never even visited the server. The more transactions there are in the network and the more players there are on the server, the slower this code will work. Because with each transaction, iteration takes place over all the players on the server and their wallets.
**[Before](https://i.imgur.com/fwBHIMf.png)** > **[After](https://i.imgur.com/nhnpmRX.png)**
I added storage of wallets in HashMap, which helped to optimize this method very much. Now, regardless of the number of transactions and players online, this method will always work very quickly and at the same speed.

### 2. Players.paymentListener_handleSecondaryWalletRemovedEvent()
This method never deleted the player's wallets because it created a new Wallet object each time and called the equals() method. But equals() method will not work as expected because it is not overridden in the Wallet class. As a result, with each iteration through the player's wallets, a new Wallet object is created, which loads the wallet balance into the constructor and is not deleted, because the equals() method is not implemented in the Wallet class.
**[Before](https://i.imgur.com/ZQwH3tz.png)** > **[After](https://i.imgur.com/hPhwYOH.png)**
I simplified the check by simply comparing the wallet address (String) and also implemented the hashCode() and equals() method in the NFTPlayer and Wallet objects. Implementing these methods will help avoid duplication of objects in collections, this will be especially useful for developers who want to save these objects to their collections.

### 3. NFTPlayer.isLinked()
This method in a certain situation could give incorrect information. When the Players.paymentListener_handlePrimaryWalletSetEvent() method is called, it sets the primary wallet but does not change the linked variable.