### PR TITLE
AsyncPlayerPaidFromServerWalletEvent

### DIFF
--- a/src/main/java/com/nftworlds/wallet/event/AsyncPlayerPaidFromServerWalletEvent.java
+++ b/src/main/java/com/nftworlds/wallet/event/AsyncPlayerPaidFromServerWalletEvent.java
@@ -1,0 +1,42 @@
+package com.nftworlds.wallet.event;
+
+import com.nftworlds.wallet.objects.Network;
+import lombok.Getter;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+public class AsyncPlayerPaidFromServerWalletEvent extends Event {
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Player receiver;
+    private final double amount;
+    private final Network network;
+    private final String reason;
+
+    private boolean defaultReceiveMessage = true;
+
+    public AsyncPlayerPaidFromServerWalletEvent(Player receiver, double amount, Network network, String reason) {
+        super(true);
+        this.receiver = receiver;
+        this.amount = amount;
+        this.network = network;
+        this.reason = reason;
+    }
+
+    public void disableDefaultReceiveMessage() {
+        this.defaultReceiveMessage = false;
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/src/main/java/com/nftworlds/wallet/event/AsyncPlayerPaidFromServerWalletEvent.java
+++ b/src/main/java/com/nftworlds/wallet/event/AsyncPlayerPaidFromServerWalletEvent.java
@@ -2,32 +2,37 @@ package com.nftworlds.wallet.event;
 
 import com.nftworlds.wallet.objects.Network;
 import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
 
 @Getter
 public class AsyncPlayerPaidFromServerWalletEvent extends Event {
     private static final HandlerList handlers = new HandlerList();
 
-    private final Player receiver;
+    private final OfflinePlayer receiver;
     private final double amount;
     private final Network network;
     private final String reason;
+    private final TransactionReceipt transactionReceipt;
+    private final String receiptLink;
 
-    private boolean defaultReceiveMessage = true;
+    @Setter
+    private boolean defaultReceiveMessage;
 
-    public AsyncPlayerPaidFromServerWalletEvent(Player receiver, double amount, Network network, String reason) {
+    public AsyncPlayerPaidFromServerWalletEvent(Player receiver, double amount, Network network, String reason, TransactionReceipt transactionReceipt, String receiptLink) {
         super(true);
         this.receiver = receiver;
         this.amount = amount;
         this.network = network;
         this.reason = reason;
-    }
-
-    public void disableDefaultReceiveMessage() {
-        this.defaultReceiveMessage = false;
+        this.transactionReceipt = transactionReceipt;
+        this.receiptLink = receiptLink;
+        this.defaultReceiveMessage = true;
     }
 
     @NotNull

--- a/src/main/java/com/nftworlds/wallet/objects/Wallet.java
+++ b/src/main/java/com/nftworlds/wallet/objects/Wallet.java
@@ -274,16 +274,14 @@ public class Wallet {
             try {
                 final PolygonWRLDToken polygonWRLDTokenContract = NFTWorlds.getInstance().getWrld().getPolygonWRLDTokenContract();
                 polygonWRLDTokenContract.transfer(this.getAddress(), sending.toBigInteger()).sendAsync().thenAccept((c) -> {
-                    AsyncPlayerPaidFromServerWalletEvent walletEvent = new AsyncPlayerPaidFromServerWalletEvent(paidPlayer, amount, network, reason);
+                    final String receiptLink = "https://polygonscan.com/tx/" + c.getTransactionHash();
+                    AsyncPlayerPaidFromServerWalletEvent walletEvent = new AsyncPlayerPaidFromServerWalletEvent(paidPlayer, amount, network, reason, c, receiptLink);
+                    walletEvent.callEvent();
 
                     if (walletEvent.isDefaultReceiveMessage()) {
                         paidPlayer.sendMessage(ChatColor.translateAlternateColorCodes('&',
-                                "&6You've been paid! &7Reason&f: " + reason + "\n" +
-                                        "&a&nhttps://polygonscan.com/tx/" +
-                                        c.getTransactionHash() + "&r\n "));
+                                "&6You've been paid! &7Reason:&f: " + reason + "\n &a&n" + receiptLink + "&r\n"));
                     }
-
-                    walletEvent.callEvent();
                 });
             } catch (Exception e) {
                 NFTWorlds.getInstance().getLogger().warning("caught error in payWrld:");


### PR DESCRIPTION
I ran into a situation on WorldBlocks where I need to determine if a user actually got the wrld transfer successfully. For some reason it doesn't always go through. This event would be very useful for me, so that I can add more logs, and make sure players always get their wrld, even if the plugin has an issue.