### PR TITLE
Optimize & fix NFT detection

### DIFF
--- a/src/main/java/com/nftworlds/wallet/objects/Wallet.java
+++ b/src/main/java/com/nftworlds/wallet/objects/Wallet.java
@@ -2,6 +2,7 @@ package com.nftworlds.wallet.objects;
 
 import com.nftworlds.wallet.NFTWorlds;
 import com.nftworlds.wallet.contracts.wrappers.common.ERC20;
+import com.nftworlds.wallet.contracts.wrappers.common.ERC721;
 import com.nftworlds.wallet.contracts.wrappers.polygon.PolygonWRLDToken;
 import com.nftworlds.wallet.event.AsyncPlayerPaidFromServerWalletEvent;
 import com.nftworlds.wallet.objects.payments.PaymentRequest;
@@ -178,24 +179,32 @@ public class Wallet {
     }
 
     public boolean doesPlayerOwnNFTInCollection(Network network, String contractAddress) {
-        String baseURL;
+        ERC721 erc721 = null;
         if (network.equals(Network.ETHEREUM)) {
-            baseURL = NFTWorlds.getInstance().getNftConfig().getEthereumHttpsRpc();
+            erc721 = ERC721.load(
+                contractAddress,
+                NFTWorlds.getInstance().getEthereumRPC().getEthereumWeb3j(),
+                Credentials.create(NFTWorlds.getInstance().getNftConfig().getServerPrivateKey()),
+                new DefaultGasProvider()
+            );
         } else if (network.equals(Network.POLYGON)) {
-            baseURL = NFTWorlds.getInstance().getNftConfig().getPolygonHttpsRpc();
+            erc721 = ERC721.load(
+                contractAddress,
+                NFTWorlds.getInstance().getPolygonRPC().getPolygonWeb3j(),
+                Credentials.create(NFTWorlds.getInstance().getNftConfig().getServerPrivateKey()),
+                new DefaultGasProvider()
+            );
         } else {
             return false;
         }
-        String url = baseURL + "/getNFTs?owner=" + address + "&contractAddresses[]=" + contractAddress;
-        NFTWorlds.getInstance().getLogger().info("Performing NFT lookup with URL " + baseURL);
+
         try {
-            JSONObject payload = new JSONObject(HttpClient.newHttpClient().send(HttpRequest.newBuilder().uri(URI.create(url)).build(), HttpResponse.BodyHandlers.ofString()).body());
-            JSONArray ownedNFTs = (JSONArray) payload.get("ownedNfts");
-            return ownedNFTs.length() > 0;
+            BigInteger balance = erc721.balanceOf(address).send();
+            return balance.compareTo(BigInteger.ZERO) > 0; //return true if address owns more than 1 NFT
         } catch (Exception e) {
-            NFTWorlds.getInstance().getLogger().info("Error when parsing response from " + url);
+            e.printStackTrace();
+            return false;
         }
-        return false;
     }
 
     /**

--- a/src/main/java/com/nftworlds/wallet/objects/Wallet.java
+++ b/src/main/java/com/nftworlds/wallet/objects/Wallet.java
@@ -200,7 +200,7 @@ public class Wallet {
 
         try {
             BigInteger balance = erc721.balanceOf(address).send();
-            return balance.compareTo(BigInteger.ZERO) > 0; //return true if address owns more than 1 NFT
+            return balance.compareTo(BigInteger.ZERO) > 0; //return true if address owns at least 1 NFT from this contract
         } catch (Exception e) {
             e.printStackTrace();
             return false;


### PR DESCRIPTION
Some addresses like 0x0847ab7743a4aeBF9d43FB4d0649f6f365B0D81e and 0x81563CDa0bE02474362f7138dfc8dE6A3e334558 are not being detected correctly as GB holders due to Alchemy's Enhanced RPC getNFTs procedure not returning their NFTs.
This PR uses ERC721's function balanceOf to save on bandwidth and provide a more general way of detecting if a player has a NFT (without requiring an Alchemy RPC).